### PR TITLE
Update collectFshFilesForPath to not check the same folder multiple times

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,14 +2,23 @@ import fs from 'fs';
 import path from 'path';
 import { TextDocument, Position } from 'vscode';
 
-export function collectFshFilesForPath(filepath: string, fshFiles: string[]): void {
-  const stats = fs.statSync(filepath);
+export function collectFshFilesForPath(
+  filepath: string,
+  fshFiles: string[] = [],
+  visitedPaths: Set<string> = new Set()
+) {
+  const realPath = fs.realpathSync(filepath);
+  if (visitedPaths.has(realPath)) {
+    return;
+  }
+  visitedPaths.add(realPath);
+  const stats = fs.statSync(realPath);
   if (stats.isDirectory()) {
-    fs.readdirSync(filepath).forEach(file => {
-      collectFshFilesForPath(path.join(filepath, file), fshFiles);
+    fs.readdirSync(realPath).forEach(file => {
+      collectFshFilesForPath(path.join(realPath, file), fshFiles, visitedPaths);
     });
   } else if (filepath.endsWith('.fsh')) {
-    fshFiles.push(filepath);
+    fshFiles.push(realPath);
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { TextDocument, Position } from 'vscode';
 
 export function collectFshFilesForPath(
   filepath: string,
-  fshFiles: string[] = [],
+  fshFiles: string[],
   visitedPaths: Set<string> = new Set()
 ) {
   const realPath = fs.realpathSync(filepath);


### PR DESCRIPTION
**Description:**
The FSH extension was causing pretty bad CPU issues for my team. We work in a monorepo using pnpm workspaces, which means that all our packages, internal and external, are linked using symlinks in node_modules.  The "find the fsh files in workspace" step didn't have logic to prevent the same folders from being repeatedly checked for every time they're added as a dependency to another package.

This PR does two things - 1) use realpath in fs, which will resolve symlink paths, and 2) keeps track of all the realpaths that have been visited and do an immediate return if the folder has been visited before. This should fix our issue.

**Testing Instructions:**
It passes the previously existing tests and returns the proper .fsh files.

**Related Issue:**
N/A